### PR TITLE
Add requirements and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ You can find some examples using the MCTS here:
 Feel free to raise a new issue for any new feature or bug you've spotted. Pull requests are also welcomed if you're
 interested in directly improving the project.
 
+### Getting Started
+
+1. Create a virtual environment: `python -m venv .venv`
+2. Activate the environment and install dependencies: `pip install -r requirements.txt`
+3. Install the package in editable mode to work on it locally: `pip install -e .`
+4. Run tests with `pytest` before submitting a pull request.
+
 ### Coding Guidelines
 
 Commit message should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+setuptools>=40


### PR DESCRIPTION
## Summary
- add minimal `requirements.txt`
- configure dependabot for GitHub Actions and pip
- document how to get started contributing

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68540644e24c8322921bcd81afb65bbf