### PR TITLE
Add basic test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . pytest
+      - name: Run tests
+        run: pytest -q
       - name: Build Package
         uses: casperdcl/deploy-pypi@v2
         with:

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+# Allow importing the package from the repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mcts.searcher.mcts import MCTS, random_policy
+from mcts.example.naughtsandcrosses import NaughtsAndCrossesState
+from mcts.example.connectmnk import ConnectMNKState
+
+
+def test_mcts_returns_valid_action():
+    state = NaughtsAndCrossesState()
+    searcher = MCTS(iteration_limit=10)
+    action = searcher.search(initial_state=state)
+    assert action in state.get_possible_actions()
+
+
+def test_random_policy_returns_reward():
+    reward = random_policy(NaughtsAndCrossesState())
+    assert reward in (-1, 0, 1)
+
+
+def test_connectmnk_horizontal_win():
+    state = ConnectMNKState(mColumns=3, nRows=3, kConnections=3)
+    state.board[0][0] = 1
+    state.board[0][1] = 1
+    state.board[0][2] = 1
+    assert state.is_terminal()
+    assert state.get_reward() == 1
+
+
+def test_naughtsandcrosses_terminal_reward_row():
+    state = NaughtsAndCrossesState()
+    state.board[0] = [1, 1, 1]
+    assert state.is_terminal()
+    assert state.get_reward() == 1


### PR DESCRIPTION
## Summary
- add initial tests for MCTS, state implementations and random policy
- run test suite in CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685407ce40708322865ccfda1f7e4cff