### PR TITLE
Fix backpropagate spelling and add parallel search tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ print(best_action)  # the best action to take found within the time limit
 print(reward)  # the expected reward for the best action
 ```
 
+### Parallel processing
+
+For faster rollouts you can run multiple worker processes using `search_parallel`.
+Simply provide the desired number of jobs:
+
+```python
+best_action = searcher.search_parallel(initial_state=initial_state, n_jobs=4)
+```
+
 **Examples**
 
 You can find some examples using the MCTS here:

--- a/mcts/searcher/mcts.py
+++ b/mcts/searcher/mcts.py
@@ -172,9 +172,9 @@ class MCTS:
             
             for index, reward in return_dict.items():
             #for index, rez in return_dict.items():
-                self.backpropogate(input_nodes[index], reward)
+                self.backpropagate(input_nodes[index], reward)
                 #node, reward = rez
-                #self.backpropogate(node, reward)
+                #self.backpropagate(node, reward)
             
         best_child = self.get_best_child(self.root, 0)
         #best_child = self.get_best_child(root_shared, 0)
@@ -197,7 +197,7 @@ class MCTS:
         """
         node = self.select_node(self.root)
         reward = self.rollout_policy(node.state)
-        self.backpropogate(node, reward)
+        self.backpropagate(node, reward)
 
     def select_node(self, node: TreeNode) -> TreeNode:
         while not node.is_terminal:
@@ -222,7 +222,7 @@ class MCTS:
 
         raise Exception("Should never reach here")
 
-    def backpropogate(self, node: TreeNode, reward: float):
+    def backpropagate(self, node: TreeNode, reward: float):
         while node is not None:
             node.numVisits += 1
             node.totalReward += reward

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -5,6 +5,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mcts.searcher.mcts import MCTS, random_policy
+import pytest
 from mcts.example.naughtsandcrosses import NaughtsAndCrossesState
 from mcts.example.connectmnk import ConnectMNKState
 
@@ -35,3 +36,17 @@ def test_naughtsandcrosses_terminal_reward_row():
     state.board[0] = [1, 1, 1]
     assert state.is_terminal()
     assert state.get_reward() == 1
+
+
+def test_search_parallel_returns_valid_action():
+    state = NaughtsAndCrossesState()
+    searcher = MCTS(iteration_limit=10)
+    action = searcher.search_parallel(initial_state=state, n_jobs=2)
+    assert action in state.get_possible_actions()
+
+
+def test_search_parallel_disallows_time_limit():
+    state = NaughtsAndCrossesState()
+    searcher = MCTS(time_limit=100)
+    with pytest.raises(NotImplementedError):
+        searcher.search_parallel(initial_state=state, n_jobs=2)


### PR DESCRIPTION
## Summary
- correct `backpropagate` spelling
- document new parallel search API
- add tests for search_parallel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686236efb29c8322abf7547975621784